### PR TITLE
fix: add class SelfCleaningLiveData

### DIFF
--- a/solutions/devsprint-higor-silva-2/app/src/main/java/com/devpass/mynotes/domain/util/SelfCleaningLiveData.kt
+++ b/solutions/devsprint-higor-silva-2/app/src/main/java/com/devpass/mynotes/domain/util/SelfCleaningLiveData.kt
@@ -1,0 +1,11 @@
+package com.devpass.mynotes.domain.util
+
+import androidx.lifecycle.MutableLiveData
+
+class SelfCleaningLiveData<T> : MutableLiveData<T>(){
+    override fun onInactive() {
+        super.onInactive()
+        value = null
+    }
+
+}

--- a/solutions/devsprint-higor-silva-2/app/src/main/java/com/devpass/mynotes/presentation/adapter/NotesListAdapter.kt
+++ b/solutions/devsprint-higor-silva-2/app/src/main/java/com/devpass/mynotes/presentation/adapter/NotesListAdapter.kt
@@ -1,5 +1,6 @@
 package com.devpass.mynotes.presentation.adapter
 
+import android.content.Context
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -13,7 +14,7 @@ import com.devpass.mynotes.domain.model.Note
 
 class NotesListAdapter(
     private val edit: (Note) -> Unit,
-    private val delete: (Note, Int) -> Unit
+    private val delete: (Note) -> Unit,
 ) :
     ListAdapter<Note, NotesListAdapter.NotesViewHolder>(NotesListAdapter) {
 
@@ -32,7 +33,7 @@ class NotesListAdapter(
             }
 
             deleteButton.setOnClickListener {
-                delete(note, position)
+                delete(note)
             }
         }
     }

--- a/solutions/devsprint-higor-silva-2/app/src/main/java/com/devpass/mynotes/presentation/adapter/NotesListAdapter.kt
+++ b/solutions/devsprint-higor-silva-2/app/src/main/java/com/devpass/mynotes/presentation/adapter/NotesListAdapter.kt
@@ -15,7 +15,7 @@ import java.text.SimpleDateFormat
 
 class NotesListAdapter(
     private val edit: (Note) -> Unit,
-    private val delete: (Note) -> Unit,
+    private val delete: (Note) -> Unit
 ) :
     ListAdapter<Note, NotesListAdapter.NotesViewHolder>(NotesListAdapter) {
 

--- a/solutions/devsprint-higor-silva-2/app/src/main/java/com/devpass/mynotes/presentation/notes/NotesFragment.kt
+++ b/solutions/devsprint-higor-silva-2/app/src/main/java/com/devpass/mynotes/presentation/notes/NotesFragment.kt
@@ -93,8 +93,8 @@ class NotesFragment : Fragment() {
         }.show()
     }
 
-    private fun onDeleteButtonClicked(noteDeleted: Note, position: Int){
+    private fun onDeleteButtonClicked(noteDeleted: Note){
         viewModel.deleteNote(noteDeleted)
-        adapter.notifyItemRemoved(position)
+        viewModel.getNotes()
     }
 }

--- a/solutions/devsprint-higor-silva-2/app/src/main/java/com/devpass/mynotes/presentation/notes/NotesViewModel.kt
+++ b/solutions/devsprint-higor-silva-2/app/src/main/java/com/devpass/mynotes/presentation/notes/NotesViewModel.kt
@@ -1,12 +1,10 @@
 package com.devpass.mynotes.presentation.notes
 
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.*
 import com.devpass.mynotes.domain.exceptions.InvalidNoteException
 import com.devpass.mynotes.domain.model.Note
 import com.devpass.mynotes.domain.usecase.NotesManagerUseCase
+import com.devpass.mynotes.domain.util.SelfCleaningLiveData
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -24,7 +22,7 @@ class NotesViewModel @Inject constructor(
     private val currentList = MutableLiveData<List<Note>>()
     fun observeCurrentList(): LiveData<List<Note>> = currentList
 
-    var deletedNote = MutableLiveData<Note?>()
+    var deletedNote = SelfCleaningLiveData<Note?>()
 
     init {
         getNotes()


### PR DESCRIPTION
Implementando classe que herda de MutableLiveDate para atribuir null ao value quando LiveData tiver inativo; Substitui o adapter.notifyItemRemoved() pelo viewModel.getNotes() para tentar resolver o bug nota fantasma na ui